### PR TITLE
feature/section-6

### DIFF
--- a/src/main/java/hello/proxy/ProxyApplication.java
+++ b/src/main/java/hello/proxy/ProxyApplication.java
@@ -1,6 +1,6 @@
 package hello.proxy;
 
-import hello.proxy.config.v2_dynamicproxy.DynamicProxyBasicConfig;
+import hello.proxy.config.v3_proxyfactory.ProxyFactoryConfigV2;
 import hello.proxy.trace.logtrace.LogTrace;
 import hello.proxy.trace.logtrace.ThreadLocalLogTrace;
 import org.springframework.boot.SpringApplication;
@@ -12,7 +12,9 @@ import org.springframework.context.annotation.Import;
 //@Import(AppV1Config.class)
 //@Import(InterfaceProxyConfig.class)
 //@Import(ConcreteProxyConfig.class)
-@Import(DynamicProxyBasicConfig.class)
+//@Import(DynamicProxyBasicConfig.class)
+//@Import(ProxyFactoryConfigV1.class)
+@Import(ProxyFactoryConfigV2.class)
 @SpringBootApplication(scanBasePackages = "hello.proxy.app") //주의
 public class ProxyApplication {
 

--- a/src/main/java/hello/proxy/config/v3_proxyfactory/ProxyFactoryConfigV1.java
+++ b/src/main/java/hello/proxy/config/v3_proxyfactory/ProxyFactoryConfigV1.java
@@ -1,0 +1,57 @@
+package hello.proxy.config.v3_proxyfactory;
+
+import hello.proxy.app.v1.*;
+import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
+import hello.proxy.trace.logtrace.LogTrace;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class ProxyFactoryConfigV1 {
+
+    @Bean
+    public OrderControllerV1 orderControllerV1(LogTrace logTrace) {
+        OrderControllerV1 orderController = new OrderControllerV1Impl(orderServiceV1(logTrace));
+        ProxyFactory factory = new ProxyFactory(orderController);
+        factory.addAdvisor(getAdvisor(logTrace));
+        OrderControllerV1 proxy = (OrderControllerV1) factory.getProxy();
+        log.info("ProxyFactory proxy={}, target={}", proxy.getClass(), orderController.getClass());
+        return proxy;
+    }
+
+    @Bean
+    public OrderServiceV1 orderServiceV1(LogTrace logTrace) {
+        OrderServiceV1 orderService = new OrderServiceV1Impl(orderRepositoryV1(logTrace));
+        ProxyFactory factory = new ProxyFactory(orderService);
+        factory.addAdvisor(getAdvisor(logTrace));
+        OrderServiceV1 proxy = (OrderServiceV1) factory.getProxy();
+        log.info("ProxyFactory proxy={}, target={}", proxy.getClass(), orderService.getClass());
+        return proxy;
+    }
+
+    @Bean
+    public OrderRepositoryV1 orderRepositoryV1(LogTrace logTrace) {
+        OrderRepositoryV1Impl orderRepository = new OrderRepositoryV1Impl();
+
+        ProxyFactory factory = new ProxyFactory(orderRepository);
+        factory.addAdvisor(getAdvisor(logTrace));
+        OrderRepositoryV1 proxy = (OrderRepositoryV1) factory.getProxy();
+        log.info("ProxyFactory proxy={}, target={}", proxy.getClass(), orderRepository.getClass());
+        return proxy;
+    }
+
+    private Advisor getAdvisor(LogTrace logTrace) {
+        //pointcut
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice advice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, advice);
+    }
+}

--- a/src/main/java/hello/proxy/config/v3_proxyfactory/ProxyFactoryConfigV2.java
+++ b/src/main/java/hello/proxy/config/v3_proxyfactory/ProxyFactoryConfigV2.java
@@ -1,0 +1,60 @@
+package hello.proxy.config.v3_proxyfactory;
+
+import hello.proxy.app.v2.OrderControllerV2;
+import hello.proxy.app.v2.OrderRepositoryV2;
+import hello.proxy.app.v2.OrderServiceV2;
+import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
+import hello.proxy.trace.logtrace.LogTrace;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class ProxyFactoryConfigV2 {
+
+    @Bean
+    public OrderControllerV2 orderControllerV2(LogTrace logTrace) {
+        OrderControllerV2 orderController = new OrderControllerV2(orderServiceV2(logTrace));
+        ProxyFactory factory = new ProxyFactory(orderController);
+        factory.addAdvisor(getAdvisor(logTrace));
+        OrderControllerV2 proxy = (OrderControllerV2) factory.getProxy();
+        log.info("ProxyFactory proxy={}, target={}", proxy.getClass(), orderController.getClass());
+        return proxy;
+    }
+
+    @Bean
+    public OrderServiceV2 orderServiceV2(LogTrace logTrace) {
+        OrderServiceV2 orderService = new OrderServiceV2(orderRepositoryV2(logTrace));
+        ProxyFactory factory = new ProxyFactory(orderService);
+        factory.addAdvisor(getAdvisor(logTrace));
+        OrderServiceV2 proxy = (OrderServiceV2) factory.getProxy();
+        log.info("ProxyFactory proxy={}, target={}", proxy.getClass(), orderService.getClass());
+        return proxy;
+    }
+
+    @Bean
+    public OrderRepositoryV2 orderRepositoryV2(LogTrace logTrace) {
+        OrderRepositoryV2 orderRepository = new OrderRepositoryV2();
+
+        ProxyFactory factory = new ProxyFactory(orderRepository);
+        factory.addAdvisor(getAdvisor(logTrace));
+        OrderRepositoryV2 proxy = (OrderRepositoryV2) factory.getProxy();
+        log.info("ProxyFactory proxy={}, target={}", proxy.getClass(), orderRepository.getClass());
+        return proxy;
+    }
+
+    private Advisor getAdvisor(LogTrace logTrace) {
+        //pointcut
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice advice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, advice);
+    }
+
+}

--- a/src/main/java/hello/proxy/config/v3_proxyfactory/advice/LogTraceAdvice.java
+++ b/src/main/java/hello/proxy/config/v3_proxyfactory/advice/LogTraceAdvice.java
@@ -1,0 +1,37 @@
+package hello.proxy.config.v3_proxyfactory.advice;
+
+import hello.proxy.trace.TraceStatus;
+import hello.proxy.trace.logtrace.LogTrace;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.lang.reflect.Method;
+
+public class LogTraceAdvice implements MethodInterceptor {
+
+    private final LogTrace logTrace;
+
+    public LogTraceAdvice(LogTrace logTrace) {
+        this.logTrace = logTrace;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        TraceStatus status = null;
+        try {
+            Method method = invocation.getMethod();
+            String message = method.getDeclaringClass().getSimpleName() + "." +
+                    method.getName() + "()";
+            status = logTrace.begin(message);
+
+            //로직 호출
+            Object result = invocation.proceed();
+
+            logTrace.end(status);
+            return result;
+        } catch (Exception e) {
+            logTrace.exception(status, e);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/hello/proxy/advisor/AdvisorTest.java
+++ b/src/test/java/hello/proxy/advisor/AdvisorTest.java
@@ -1,0 +1,123 @@
+package hello.proxy.advisor;
+
+import hello.proxy.common.advice.TimeAdvice;
+import hello.proxy.common.service.ServiceImpl;
+import hello.proxy.common.service.ServiceInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.ClassFilter;
+import org.springframework.aop.MethodMatcher;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+
+import java.lang.reflect.Method;
+
+/**
+ * <h1>포인트컷( Pointcut )</h1>
+ * <p>
+ * 어디에 부가 기능을 적용할지, 어디에 부가 기능을 적용하지 않을지 판단하는
+ * 필터링 로직이다. 주로 클래스와 메서드 이름으로 필터링 한다. 이름 그대로 어떤 포인트(Point)에 기능을
+ * 적용할지 하지 않을지 잘라서(cut) 구분하는 것이다.
+ * <p>
+ *
+ * <h1>어드바이스( Advice )</h1>
+ * <p>
+ * 이전에 본 것 처럼 프록시가 호출하는 부가 기능이다. 단순하게 프록시 로직이라
+ * 생각하면 된다.
+ * <p>
+ *
+ * <h1>어드바이저( Advisor )</h1>
+ * <p>
+ * 단순하게 하나의 포인트컷과 하나의 어드바이스를 가지고 있는 것이다. 쉽게
+ * 이야기해서 포인트컷1 + 어드바이스1이다
+ */
+@Slf4j
+public class AdvisorTest {
+
+    @Test
+    void advisorTest1() {
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor(Pointcut.TRUE, new TimeAdvice());
+        proxyFactory.addAdvisor(advisor);
+        ServiceInterface proxy = (ServiceInterface) proxyFactory.getProxy();
+
+        proxy.save();
+        proxy.find();
+    }
+
+    @Test
+    @DisplayName("직접 만든 포인트컷")
+    void advisorTest2() {
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor(new MyPointcut(), new TimeAdvice()); // MyPointcut이라는 custom point cut
+        proxyFactory.addAdvisor(advisor);
+        ServiceInterface proxy = (ServiceInterface) proxyFactory.getProxy();
+
+        proxy.save();
+        proxy.find();
+    }
+
+    @Test
+    @DisplayName("스프링이 제공하는 포인트컷")
+    void advisorTest3() {
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut(); // spring이 제공하는 point cut
+        pointcut.setMappedNames("save"); // 메소드 이름이 save인 경우에만 어드바이스 로직을 태운다.
+        DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor(pointcut, new TimeAdvice());
+        proxyFactory.addAdvisor(advisor);
+        ServiceInterface proxy = (ServiceInterface) proxyFactory.getProxy();
+
+        proxy.save();
+        proxy.find();
+    }
+
+    static class MyPointcut implements Pointcut {
+
+        @Override
+        public ClassFilter getClassFilter() {
+            return ClassFilter.TRUE;
+        }
+
+        @Override
+        public MethodMatcher getMethodMatcher() {
+            return new MyMethodMatcher();
+        }
+    }
+
+    static class MyMethodMatcher implements MethodMatcher {
+
+        private String matchName = "save";
+
+        @Override
+        public boolean matches(Method method, Class<?> targetClass) {
+            boolean result = method.getName().equals(matchName);
+            log.info("포인트컷 호출 method={} targetClass={}", method.getName(), targetClass);
+            log.info("포인트컷 결과 result={}", result);
+            return result;
+        }
+
+        /**
+         * isRuntime() 이 false 인 경우
+         * 클래스의 정적 정보만 사용하기 때문에 스프링이 내부에서 캐싱을 통해 성능 향상이 가능하다
+         * <p>
+         * isRuntime() 이 true 인 경우
+         * 매개변수가 동적으로 변경된다고 가정하기 때문에 캐싱을 하지 않는다
+         */
+        @Override
+        public boolean isRuntime() {
+            return false;
+        }
+
+        @Override
+        public boolean matches(Method method, Class<?> targetClass, Object... args) {
+            return false;
+        }
+    }
+
+}

--- a/src/test/java/hello/proxy/advisor/MultiAdvisorTest.java
+++ b/src/test/java/hello/proxy/advisor/MultiAdvisorTest.java
@@ -1,0 +1,78 @@
+package hello.proxy.advisor;
+
+import hello.proxy.common.service.ServiceImpl;
+import hello.proxy.common.service.ServiceInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+
+public class MultiAdvisorTest {
+
+    @Test
+    @DisplayName("여러 프록시")
+    void multiAdvisorTest1() {
+        //client -> proxy2(advisor2) -> proxy1(advisor1) -> target
+
+        //프록시1 생성
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory1 = new ProxyFactory(target); // proxy1에는 target을
+        DefaultPointcutAdvisor advisor1 = new DefaultPointcutAdvisor(Pointcut.TRUE, new Advice1());
+        proxyFactory1.addAdvisor(advisor1);
+        ServiceInterface proxy1 = (ServiceInterface) proxyFactory1.getProxy();
+
+        //프록시2 생성, target -> proxy1 입력
+        ProxyFactory proxyFactory2 = new ProxyFactory(proxy1); // proxy2에는 proxy1을
+        DefaultPointcutAdvisor advisor2 = new DefaultPointcutAdvisor(Pointcut.TRUE, new Advice2());
+        proxyFactory2.addAdvisor(advisor2);
+        ServiceInterface proxy2 = (ServiceInterface) proxyFactory2.getProxy();
+
+        //실행
+        proxy2.save();
+
+    }
+
+    @Test
+    @DisplayName("하나의 프록시, 여러 어드바이저")
+    void multiAdvisorTest2() {
+        //client -> proxy -> advisor2 -> advisor1 -> target
+
+        DefaultPointcutAdvisor advisor1 = new DefaultPointcutAdvisor(Pointcut.TRUE, new Advice1());
+        DefaultPointcutAdvisor advisor2 = new DefaultPointcutAdvisor(Pointcut.TRUE, new Advice2());
+
+        //프록시1 생성
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory1 = new ProxyFactory(target);
+
+        proxyFactory1.addAdvisor(advisor2);
+        proxyFactory1.addAdvisor(advisor1);
+        ServiceInterface proxy = (ServiceInterface) proxyFactory1.getProxy();
+
+        //실행
+        proxy.save();
+
+    }
+
+    @Slf4j
+    static class Advice1 implements MethodInterceptor {
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            log.info("advice1 호출");
+            return invocation.proceed();
+        }
+    }
+
+    @Slf4j
+    static class Advice2 implements MethodInterceptor {
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            log.info("advice2 호출");
+            return invocation.proceed();
+        }
+    }
+
+}

--- a/src/test/java/hello/proxy/common/advice/TimeAdvice.java
+++ b/src/test/java/hello/proxy/common/advice/TimeAdvice.java
@@ -9,6 +9,10 @@ import org.aopalliance.intercept.MethodInvocation;
  */
 @Slf4j
 public class TimeAdvice implements MethodInterceptor {
+
+    /**
+     * target 클래스의 정보는 MethodInvocation안에 모두 포함되어있다.
+     */
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
         log.info("TimeProxy 실행");

--- a/src/test/java/hello/proxy/proxyfactory/ProxyFactoryTest.java
+++ b/src/test/java/hello/proxy/proxyfactory/ProxyFactoryTest.java
@@ -1,0 +1,70 @@
+package hello.proxy.proxyfactory;
+
+import hello.proxy.common.advice.TimeAdvice;
+import hello.proxy.common.service.ConcreteService;
+import hello.proxy.common.service.ServiceImpl;
+import hello.proxy.common.service.ServiceInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class ProxyFactoryTest {
+
+    @Test
+    @DisplayName("인터페이스가 있으면 JDK 동적 프록시 사용")
+    void interfaceProxy() {
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.addAdvice(new TimeAdvice());
+        ServiceInterface proxy = (ServiceInterface) proxyFactory.getProxy();
+        log.info("targetClass={}", target.getClass());
+        log.info("proxyClass={}", proxy.getClass());
+
+        proxy.save();
+
+        assertThat(AopUtils.isAopProxy(proxy)).isTrue();
+        assertThat(AopUtils.isJdkDynamicProxy(proxy)).isTrue();
+        assertThat(AopUtils.isCglibProxy(proxy)).isFalse(); // <- interface로 프록시를 만든것이기 때문이다.
+    }
+
+    @Test
+    @DisplayName("구체 클래스만 있으면 CGLIB 사용")
+    void concreteProxy() {
+        ConcreteService target = new ConcreteService();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.addAdvice(new TimeAdvice());
+        ConcreteService proxy = (ConcreteService) proxyFactory.getProxy();
+        log.info("targetClass={}", target.getClass());
+        log.info("proxyClass={}", proxy.getClass());
+
+        proxy.call();
+
+        assertThat(AopUtils.isAopProxy(proxy)).isTrue();
+        assertThat(AopUtils.isJdkDynamicProxy(proxy)).isFalse();
+        assertThat(AopUtils.isCglibProxy(proxy)).isTrue();
+    }
+
+    @Test
+    @DisplayName("ProxyTargetClass 옵션을 사용하면 인터페이스가 있어도 CGLIB를 사용하고, 클래스 기반 프록시 사용")
+    void proxyTargetClass() {
+        ServiceInterface target = new ServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(true); // <-
+        proxyFactory.addAdvice(new TimeAdvice());
+        ServiceInterface proxy = (ServiceInterface) proxyFactory.getProxy();
+        log.info("targetClass={}", target.getClass());
+        log.info("proxyClass={}", proxy.getClass());
+
+        proxy.save();
+
+        assertThat(AopUtils.isAopProxy(proxy)).isTrue();
+        assertThat(AopUtils.isJdkDynamicProxy(proxy)).isFalse();
+        assertThat(AopUtils.isCglibProxy(proxy)).isTrue();
+    }
+
+}


### PR DESCRIPTION
# spring의 proxyFactory

![image](https://github.com/StudyForBetterLife/Proxy/assets/44316546/b9042839-a0f9-4162-9316-b39fca923c75)

> 프록시 팩토리의 기술 선택 방법
- 대상에 인터페이스가 있으면: JDK 동적 프록시, 인터페이스 기반 프록시
- 대상에 인터페이스가 없으면: CGLIB, 구체 클래스 기반 프록시
- proxyTargetClass=true : CGLIB, 구체 클래스 기반 프록시, 인터페이스 여부와 상관없음

# PointCut, Advice, Advisor

## 포인트컷( Pointcut ) : 대상 여부를 확인하는 필터 역할만 담

어디에 부가 기능을 적용할지, 어디에 부가 기능을 적용하지 않을지 판단하는 필터링 로직이다. 주로 클래스와 메서드 이름으로 필터링 한다. 이름 그대로 어떤 포인트(Point)에 기능을 적용할지 하지 않을지 잘라서(cut) 구분하는 것이다.

## 어드바이스( Advice ) : 부가 기능 로직만 담당
이전에 본 것 처럼 프록시가 호출하는 부가 기능이다. 단순하게 프록시 로직이라 생각하면 된다.

## 어드바이저( Advisor ):  포인트컷 + 어드바이스
단순하게 하나의 포인트컷과 하나의 어드바이스를 가지고 있는 것이다. 
쉽게 이야기해서 `어드바이저1 = 포인트컷1 + 어드바이스1`이다.

![image](https://github.com/StudyForBetterLife/Proxy/assets/44316546/441a54ae-cc1a-44e1-a30d-7aa526fd6a88)

# 하나의 프록시에 여러 어드바이저를 적용할 수 있다.



![image](https://github.com/StudyForBetterLife/Proxy/assets/44316546/9f0e122e-bfba-42ec-89ab-79120323489e)

```java
proxyFactory.addAdvisor(advisor1);
proxyFactory.addAdvisor(advisor2);
```

정리하자면 아래와 같은 그림이 가능하다.

![image](https://github.com/StudyForBetterLife/Proxy/assets/44316546/a0738107-e258-4617-9775-415892d46fea)

> 기억해야할 것
스프링은 AOP를 적용할 때, 최적화를 진행해서 지금처럼 프록시는 하나만 만들고, 하나의 프록시에 여러 어드바이저를 적용한다.
즉, 하나의 target 에 여러 AOP가 동시에 적용되어도, 스프링의 AOP는 target 마다 하나의 프록시만 생성한다. 이부분을 꼭 기억해두자.