### PR TITLE
feature/section-7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop' //추가
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/hello/proxy/ProxyApplication.java
+++ b/src/main/java/hello/proxy/ProxyApplication.java
@@ -1,6 +1,6 @@
 package hello.proxy;
 
-import hello.proxy.config.v3_proxyfactory.ProxyFactoryConfigV2;
+import hello.proxy.config.v4_postprocessor.BeanPostProcessorConfig;
 import hello.proxy.trace.logtrace.LogTrace;
 import hello.proxy.trace.logtrace.ThreadLocalLogTrace;
 import org.springframework.boot.SpringApplication;
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Import;
 //@Import(ConcreteProxyConfig.class)
 //@Import(DynamicProxyBasicConfig.class)
 //@Import(ProxyFactoryConfigV1.class)
-@Import(ProxyFactoryConfigV2.class)
+//@Import(ProxyFactoryConfigV2.class)
+@Import(BeanPostProcessorConfig.class)
 @SpringBootApplication(scanBasePackages = "hello.proxy.app") //주의
 public class ProxyApplication {
 

--- a/src/main/java/hello/proxy/ProxyApplication.java
+++ b/src/main/java/hello/proxy/ProxyApplication.java
@@ -1,6 +1,6 @@
 package hello.proxy;
 
-import hello.proxy.config.v4_postprocessor.BeanPostProcessorConfig;
+import hello.proxy.config.v5_autoproxy.AutoProxyConfig;
 import hello.proxy.trace.logtrace.LogTrace;
 import hello.proxy.trace.logtrace.ThreadLocalLogTrace;
 import org.springframework.boot.SpringApplication;
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Import;
 //@Import(DynamicProxyBasicConfig.class)
 //@Import(ProxyFactoryConfigV1.class)
 //@Import(ProxyFactoryConfigV2.class)
-@Import(BeanPostProcessorConfig.class)
+//@Import(BeanPostProcessorConfig.class)
+@Import(AutoProxyConfig.class)
 @SpringBootApplication(scanBasePackages = "hello.proxy.app") //주의
 public class ProxyApplication {
 

--- a/src/main/java/hello/proxy/config/v4_postprocessor/BeanPostProcessorConfig.java
+++ b/src/main/java/hello/proxy/config/v4_postprocessor/BeanPostProcessorConfig.java
@@ -1,0 +1,34 @@
+package hello.proxy.config.v4_postprocessor;
+
+import hello.proxy.config.AppV1Config;
+import hello.proxy.config.AppV2Config;
+import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
+import hello.proxy.config.v4_postprocessor.postprocessor.PackageLogTracePostProcessor;
+import hello.proxy.trace.logtrace.LogTrace;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@Configuration
+@Import({AppV1Config.class, AppV2Config.class})
+public class BeanPostProcessorConfig {
+
+    @Bean
+    public PackageLogTracePostProcessor logTracePostProcessor(LogTrace logTrace) {
+        return new PackageLogTracePostProcessor("hello.proxy.app", getAdvisor(logTrace));
+    }
+
+    private Advisor getAdvisor(LogTrace logTrace) {
+        //pointcut
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice advice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, advice);
+    }
+}

--- a/src/main/java/hello/proxy/config/v4_postprocessor/postprocessor/PackageLogTracePostProcessor.java
+++ b/src/main/java/hello/proxy/config/v4_postprocessor/postprocessor/PackageLogTracePostProcessor.java
@@ -1,0 +1,39 @@
+package hello.proxy.config.v4_postprocessor.postprocessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+@Slf4j
+public class PackageLogTracePostProcessor implements BeanPostProcessor {
+
+    private final String basePackage;
+    private final Advisor advisor;
+
+    public PackageLogTracePostProcessor(String basePackage, Advisor advisor) {
+        this.basePackage = basePackage;
+        this.advisor = advisor;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        log.info("param beanName={} bean={}", beanName, bean.getClass());
+
+        //프록시 적용 대상 여부 체크
+        //프록시 적용 대상이 아니면 원본을 그대로 진행
+        String packageName = bean.getClass().getPackageName();
+        if (!packageName.startsWith(basePackage)) {
+            return bean;
+        }
+
+        //프록시 대상이면 프록시를 만들어서 반환
+        ProxyFactory proxyFactory = new ProxyFactory(bean);
+        proxyFactory.addAdvisor(advisor);
+
+        Object proxy = proxyFactory.getProxy();
+        log.info("create proxy: target={} proxy={}", bean.getClass(), proxy.getClass());
+        return proxy;
+    }
+}

--- a/src/main/java/hello/proxy/config/v5_autoproxy/AutoProxyConfig.java
+++ b/src/main/java/hello/proxy/config/v5_autoproxy/AutoProxyConfig.java
@@ -6,6 +6,7 @@ import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
 import hello.proxy.config.v4_postprocessor.BeanPostProcessorConfig;
 import hello.proxy.trace.logtrace.LogTrace;
 import org.springframework.aop.Advisor;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.aop.support.NameMatchMethodPointcut;
 import org.springframework.context.annotation.Bean;
@@ -22,12 +23,43 @@ public class AutoProxyConfig {
      * <h1>AnnotationAwareAspectJAutoProxyCreator</h1>
      * 이 클래스는 bean으로 등록된 Advisor를 모두 찾아 자동으로 프록시를 생성해준다.
      * {@link BeanPostProcessorConfig}처럼 빈 후처리기를 통해 프록시를 빈으로 등록해줄 필요가 없어진다.
+     * <p>
+     * 다만, NameMatchMethodPointcut을 사용하게 된다면, 메소드에 request가 포함된 다른 스프링 빈에도 프록시가 적용되는 문제가 있다.
      */
-    @Bean
+//    @Bean
     public Advisor advisor1(LogTrace logTrace) {
         //pointcut
         NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
         pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice advice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, advice);
+    }
+
+
+    /**
+     * AspectJExpressionPointcut
+     * <p>
+     * AOP에 특화된 포인트컷 표현식을 적용할 수 있다
+     */
+//    @Bean
+    public Advisor advisor2(LogTrace logTrace) {
+        //pointcut
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* hello.proxy.app..*(..))");
+        //advice
+        LogTraceAdvice advice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, advice);
+    }
+
+    /**
+     * noLog()를 제외한 메소드에 대해서만 advice를 적용하도록 표현식을 수정.
+     */
+    @Bean
+    public Advisor advisor3(LogTrace logTrace) {
+        //pointcut
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* hello.proxy.app..*(..)) && !execution(* hello.proxy.app..noLog(..))");
         //advice
         LogTraceAdvice advice = new LogTraceAdvice(logTrace);
         return new DefaultPointcutAdvisor(pointcut, advice);

--- a/src/main/java/hello/proxy/config/v5_autoproxy/AutoProxyConfig.java
+++ b/src/main/java/hello/proxy/config/v5_autoproxy/AutoProxyConfig.java
@@ -1,0 +1,35 @@
+package hello.proxy.config.v5_autoproxy;
+
+import hello.proxy.config.AppV1Config;
+import hello.proxy.config.AppV2Config;
+import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
+import hello.proxy.config.v4_postprocessor.BeanPostProcessorConfig;
+import hello.proxy.trace.logtrace.LogTrace;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({AppV1Config.class, AppV2Config.class})
+public class AutoProxyConfig {
+
+    /**
+     * spring-boot-starter-aop 의존성을 추가하면, AnnotationAwareAspectJAutoProxyCreator가 빈으로 등록된다.
+     * <p>
+     * <h1>AnnotationAwareAspectJAutoProxyCreator</h1>
+     * 이 클래스는 bean으로 등록된 Advisor를 모두 찾아 자동으로 프록시를 생성해준다.
+     * {@link BeanPostProcessorConfig}처럼 빈 후처리기를 통해 프록시를 빈으로 등록해줄 필요가 없어진다.
+     */
+    @Bean
+    public Advisor advisor1(LogTrace logTrace) {
+        //pointcut
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice advice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, advice);
+    }
+}

--- a/src/test/java/hello/proxy/postprocessor/BasicTest.java
+++ b/src/test/java/hello/proxy/postprocessor/BasicTest.java
@@ -1,0 +1,48 @@
+package hello.proxy.postprocessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class BasicTest {
+
+    @Test
+    void basicConfig() {
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(BasicConfig.class);
+
+        //A는 빈으로 등록된다.
+        A a = applicationContext.getBean("beanA", A.class);
+        a.helloA();
+
+        //B는 빈으로 등록되지 않는다.
+        Assertions.assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean(B.class));
+    }
+
+    @Slf4j
+    @Configuration
+    static class BasicConfig {
+        @Bean(name = "beanA")
+        public A a() {
+            return new A();
+        }
+    }
+
+    @Slf4j
+    static class A {
+        public void helloA() {
+            log.info("hello A");
+        }
+    }
+
+    @Slf4j
+    static class B {
+        public void helloB() {
+            log.info("hello B");
+        }
+    }
+}

--- a/src/test/java/hello/proxy/postprocessor/BeanPostProcessorTest.java
+++ b/src/test/java/hello/proxy/postprocessor/BeanPostProcessorTest.java
@@ -1,0 +1,68 @@
+package hello.proxy.postprocessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class BeanPostProcessorTest {
+
+    @Test
+    void basicConfig() {
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(BeanPostProcessorConfig.class);
+
+        //beanA 이름으로 B 객체가 빈으로 등록된다.
+        B b = applicationContext.getBean("beanA", B.class);
+        b.helloB();
+
+        //A는 빈으로 등록되지 않는다.
+        Assertions.assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean(A.class));
+    }
+
+    @Slf4j
+    @Configuration
+    static class BeanPostProcessorConfig {
+        @Bean(name = "beanA")
+        public A a() {
+            return new A();
+        }
+
+        @Bean
+        public AToBPostProcessor helloPostProcessor() {
+            return new AToBPostProcessor();
+        }
+    }
+
+    @Slf4j
+    static class A {
+        public void helloA() {
+            log.info("hello A");
+        }
+    }
+
+    @Slf4j
+    static class B {
+        public void helloB() {
+            log.info("hello B");
+        }
+    }
+
+    @Slf4j
+    static class AToBPostProcessor implements BeanPostProcessor {
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            log.info("beanName={} bean={}", beanName, bean);
+            if (bean instanceof A) {
+                return new B();
+            }
+            return bean;
+        }
+    }
+}


### PR DESCRIPTION
# 빈 후처리기 동작방식

![image](https://github.com/StudyForBetterLife/Proxy/assets/44316546/31727018-2020-4db6-9012-f19bc95d702a)

1. 생성: 스프링 빈 대상이 되는 객체를 생성한다. ( @Bean , 컴포넌트 스캔 모두 포함)
2. 전달: 생성된 객체를 빈 저장소에 등록하기 직전에 빈 후처리기에 전달한다.
3. 후 처리 작업: 빈 후처리기는 전달된 스프링 빈 객체를 조작하거나 다른 객체로 바뀌치기 할 수 있다.
4. 등록: 빈 후처리기는 빈을 반환한다. 전달 된 빈을 그대로 반환하면 해당 빈이 등록되고, 바꿔치기 하면 다른 객체가 빈 저장소에 등록된다.

> 스프링 스스로도 스프링 내부의 기능을 확장하기 위해 빈 후처리기를 사용한다.

`@PostConstructor`
- 스프링 빈 생성 이후에 빈을 초기화 하는 역할을 하는 어노테이션
- 스프링은 `CommonAnnotationBeanPostProcessor`라는 빈 후처리기를 자동으로 등록한다. 
- `CommonAnnotationBeanPostProcessor`에서 @PostConstruct 애노테이션이 붙은 메서드를 호출한다.

![image](https://github.com/StudyForBetterLife/Proxy/assets/44316546/5ae2679c-3f07-4608-8543-f654450dabad)

> 빈 후처리기를 사용하면

- 수동으로 등록한 bean & 컴포넌트 스캔으로 등록한 bean에 모두 후처리 작업을 적용할 수 있다